### PR TITLE
Fix ARM docker images

### DIFF
--- a/arm32v7.dockerfile
+++ b/arm32v7.dockerfile
@@ -12,6 +12,9 @@ COPY --from=builder qemu-arm-static /usr/bin
 # Create app directory
 WORKDIR /usr/src/app
 
+# Required to build RE2
+RUN apk add python make g++
+
 # Install dependencies
 COPY package.json ./package.json
 COPY yarn.lock ./yarn.lock

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -12,6 +12,9 @@ COPY --from=builder qemu-aarch64-static /usr/bin
 # Create app directory
 WORKDIR /usr/src/app
 
+# Required to build RE2
+RUN apk add python make g++
+
 # Install dependencies
 COPY package.json ./package.json
 COPY yarn.lock ./yarn.lock


### PR DESCRIPTION
`RE2` is now transitive dependency of the `get-urls`, it is binary module supplied by google, which requires certain environment packages to be built on ARM architecture, while it's supplied as binary for `amd64`

```
yarn run v1.22.5
$ NODE_ENV=prod node bot.js
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module './build/Release/re2'
Require stack:
- /usr/src/app/node_modules/re2/re2.js
- /usr/src/app/node_modules/url-regex-safe/lib/index.js
- /usr/src/app/node_modules/get-urls/index.js
- /usr/src/app/handler/fetch.js
- /usr/src/app/bot.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/usr/src/app/node_modules/re2/re2.js:3:13)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/usr/src/app/node_modules/url-regex-safe/lib/index.js:9:11)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/usr/src/app/node_modules/re2/re2.js',
    '/usr/src/app/node_modules/url-regex-safe/lib/index.js',
    '/usr/src/app/node_modules/get-urls/index.js',
    '/usr/src/app/handler/fetch.js',
    '/usr/src/app/bot.js'
  ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```